### PR TITLE
Fix a bunch of compiler warnings

### DIFF
--- a/QextSerialPort/qextserialenumerator_p.h
+++ b/QextSerialPort/qextserialenumerator_p.h
@@ -50,9 +50,15 @@
 // probably a better way to do this
 // http://mingw-users.1079350.n2.nabble.com/DEV-BROADCAST-DEVICEINTERFACE-was-not-declared-in-this-scope-td3552762.html
 #  ifdef  __MINGW32__
+#    ifndef _WIN32_WINNT
 #    define _WIN32_WINNT 0x0500
+#    endif
+#    ifndef _WIN32_WINDOWS
 #    define _WIN32_WINDOWS 0x0500
+#    endif
+#    ifndef WINVER
 #    define WINVER 0x0500
+#  endif
 #  endif
 #  include <QtCore/qt_windows.h>
 #endif /*Q_OS_WIN*/

--- a/gcode.cpp
+++ b/gcode.cpp
@@ -1769,7 +1769,7 @@ void GCode::axisAdj(char axis, float coord, bool inv, bool absoluteAfterAxisAdj,
 {
     if (inv)
     {
-        coord =- coord;
+        coord = (-coord);
     }
 
     QString cmd = QString("G01 ").append(axis)

--- a/log4qt/helpers/datetime.cpp
+++ b/log4qt/helpers/datetime.cpp
@@ -161,7 +161,7 @@ namespace Log4Qt
 	    
 	    const QChar c = rToken.at(0);
 	    QString result;
-	    int used;
+        int used = 0;
 	    
 	    // Qt data format strings 
 	    if (rToken.startsWith(QLatin1String("dddd")))

--- a/log4qt/helpers/patternformatter.cpp
+++ b/log4qt/helpers/patternformatter.cpp
@@ -455,8 +455,8 @@ namespace Log4Qt
 		State state = LITERAL_STATE;
 		FormattingInfo formatting_info;
 		QString literal;
-		int converter_start;
-		int option_start;
+        int converter_start = 0;
+        int option_start = 0;
 		while (i < mPattern.length())
 		{
 	        // i points to the current character

--- a/log4qt/helpers/properties.cpp
+++ b/log4qt/helpers/properties.cpp
@@ -186,8 +186,8 @@ namespace Log4Qt
 		QString key;
 		QString value;
 		QString *p_string = &key;
-		uint ucs;
-		int ucs_digits;
+        uint ucs = 0;
+        int ucs_digits = 0;
 		while (i < rProperty.length())
 		{
 	        // i points to the current character. 

--- a/log4qt/logmanager.cpp
+++ b/log4qt/logmanager.cpp
@@ -423,6 +423,7 @@ namespace Log4Qt
 #else
     void LogManager::qtMessageHandler(QtMsgType type, const QMessageLogContext &context, const QString &message)
     {
+        Q_UNUSED(context);
         Level level;
         switch (type)
         {

--- a/log4qt/rollingfileappender.cpp
+++ b/log4qt/rollingfileappender.cpp
@@ -104,6 +104,11 @@ namespace Log4Qt
             setMaximumFileSize(max_file_size);
     }
 
+    QString RollingFileAppender::maxFileSize()
+    {
+        return QString("%1").arg(maximumFileSize());
+    }
+
 	
 	void RollingFileAppender::append(const LoggingEvent &rEvent)
 	{

--- a/log4qt/rollingfileappender.h
+++ b/log4qt/rollingfileappender.h
@@ -76,7 +76,7 @@ namespace Log4Qt
          *
          * \sa setMaxFileSize(), maximumFileSize()
          */
-        Q_PROPERTY(QString maxFileSize WRITE setMaxFileSize)
+        Q_PROPERTY(QString maxFileSize READ maxFileSize WRITE setMaxFileSize)
         
 	public:
 	    RollingFileAppender(QObject *pParent = 0);
@@ -97,6 +97,7 @@ namespace Log4Qt
 	    qint64 maximumFileSize() const;
 	    void setMaxBackupIndex(int maxBackupIndex);
         void setMaximumFileSize(qint64 maximumFileSize);
+        QString maxFileSize();
         void setMaxFileSize(const QString &rMaxFileSize);
 	
 	protected:

--- a/log4qt/varia/debugappender.cpp
+++ b/log4qt/varia/debugappender.cpp
@@ -89,7 +89,7 @@ namespace Log4Qt
 	        OutputDebugStringA(message.toLocal8Bit().data());
 	    });
 #else
-	    fprintf(stderr, message.toLocal8Bit().data());
+        fprintf(stderr, "%s", message.toLocal8Bit().data());
 	    fflush(stderr);
 #endif
 	}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1171,7 +1171,7 @@ void MainWindow::receiveListOut(QString msg)
 
 void MainWindow::addToStatusList(bool in, QString msg)
 {
-    msg.trimmed();
+    msg = msg.trimmed();
     msg.remove('\r');
     msg.remove('\n');
 
@@ -1204,7 +1204,7 @@ void MainWindow::addToStatusList(QStringList& list)
     QStringList cleanList;
     foreach (QString msg, list)
     {
-        msg.trimmed();
+        msg = msg.trimmed();
         msg.remove('\r');
         msg.remove('\n');
 


### PR DESCRIPTION
Fixes a bunch of mildly irritating compiler warnings in some of the libraries (log4js, QextSerialPort) with GCC on Windows and Linux, and Clang on MacOS.
