### PR TITLE
add various files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ settings
 ui_*.h
 Output/
 android/
+GrblController
+*.o
+moc_*.cpp
+qrc_*.cpp
+*.stash
+GrblController-local.iss


### PR DESCRIPTION
Various files could do with being ignored by git. This patch adds these to .gitignore:
    GrblController
    _.o
    moc__.cpp
    qrc_*.cpp
    *.stash
    GrblController-local.iss
