### PR TITLE
Fix the remaining compiler warnings on MacOS/clang

### DIFF
--- a/arcitem.cpp
+++ b/arcitem.cpp
@@ -88,12 +88,11 @@ void ArcItem::addToPath(QPainterPath& path)
     path.moveTo(screenX(ex), screenY(ey));
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void ArcItem::moveToFirst(QPainterPath& path)
 {
     // not applicable! generate error!
+    Q_UNUSED(path);
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
 double ArcItem::getXScr()
 {

--- a/gcode.cpp
+++ b/gcode.cpp
@@ -984,9 +984,10 @@ void GCode::sendStatusList(QStringList& listToSend)
 }
 
 // called once a second to capture any random strings that come from the controller
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void GCode::timerEvent(QTimerEvent *event)
 {
+    Q_UNUSED(event);
+
     if (port.isPortOpen())
     {
         char tmp[BUF_SIZE + 1] = {0};
@@ -1019,7 +1020,6 @@ void GCode::timerEvent(QTimerEvent *event)
         sendStatusList(listToSend);
     }
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
 void GCode::sendFile(QString path)
 {

--- a/grbldialog.cpp
+++ b/grbldialog.cpp
@@ -127,16 +127,16 @@ void GrblDialog::Cancel()
     this->close();
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void GrblDialog::changeValues(int row, int col)
 {
+    Q_UNUSED(col);
+
     if ((ui->table->item(row,0)->text() != originalValues.at(row))
         && ui->table->item(row,0)->text().length() > 0)
     {
         changeFlags.replace(row, true);
     }
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
 void GrblDialog::Ok()
 {

--- a/log4qt/hierarchy.cpp
+++ b/log4qt/hierarchy.cpp
@@ -75,6 +75,7 @@ namespace Log4Qt
 	    mThreshold(Level::NULL_INT),
 	    mpRootLogger(logger(QString()))
 	{
+        Q_UNUSED(mHandleQtMessages);
 	    // Store root logger to allow rootLogger() to be const
 	}
 

--- a/main.cpp
+++ b/main.cpp
@@ -142,7 +142,6 @@ void info(const char *str, ...)
     va_end(args);
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void diag(const char *str, ...)
 {
 #ifndef QT_DEBUG
@@ -157,7 +156,6 @@ void diag(const char *str, ...)
     }
 #endif
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
 void logit(GC_LOG_TYPES type, const char *str, va_list args)
 {

--- a/pointitem.cpp
+++ b/pointitem.cpp
@@ -5,17 +5,15 @@ PointItem::PointItem(double x1, double y1)
 {
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void PointItem::moveToFirst(QPainterPath& path)
 {
+    Q_UNUSED(path);
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void PointItem::addToPath(QPainterPath& path)
 {
+    Q_UNUSED(path);
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop
 
 PosItem PointItem::computeExtents()
 {

--- a/timer.cpp
+++ b/timer.cpp
@@ -20,9 +20,10 @@ void Timer::resetTimer(bool timeIt)
         timer.start();
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter" push
 void Timer::timerEvent(QTimerEvent *event)
 {
+    Q_UNUSED(event);
+
     if (timing)
     {
         int secs = timer.elapsed() / 1000;
@@ -32,4 +33,3 @@ void Timer::timerEvent(QTimerEvent *event)
         emit setRuntime(QString("%1:%2:%3").arg(hours, 2, 10, QLatin1Char('0')).arg(mins, 2, 10, QLatin1Char('0')).arg(secs, 2, 10, QLatin1Char('0')));
     }
 }
-#pragma GCC diagnostic ignored "-Wunused-parameter" pop


### PR DESCRIPTION
Clang doesn't like the gcc pragmas to ignore warnings; since
this is used just to ignore unused variables, we can use the
Q_UNUSED() macro instead (which just expands to (void)name
anyway which is portable).

I now get completely clean builds on Windows (MinGW-gcc), Linux and MacOS. Yay!
