### PR TITLE
Fix erroneous newline handling in log4qt

### DIFF
--- a/log4qt/layout.cpp
+++ b/log4qt/layout.cpp
@@ -71,14 +71,11 @@ namespace Log4Qt
 	
 	QString Layout::endOfLine()
 	{
-		// There seams to be no function in Qt for this
-		
-#ifdef Q_OS_WIN32
-		return QLatin1String("\r\n");
-#endif // Q_OS_WIN32
-//#ifdef Q_OS_MAC
-//		return QLatin1String("\r");
-//#endif // Q_OS_MAC
+        // Qt's output functions seem to handle
+        // platform specific variations of newline
+        // for us. For example, on Windows if we here
+        // return "\r\n", we'll actually get "\r\r\n"
+        // in the output.
 		return QLatin1String("\n");
 	}
 	


### PR DESCRIPTION
Qt's output functions seem to handle platform specific variations of newline for us. For example, on Windows if we output `"\r\n"`, we'll actually get `"\r\r\n"`.

It's _really_ minor, but in QtCreator, this causes lots of blank lines in the console output!
