### PR TITLE
Added missing include in Timer class

### DIFF
--- a/timer.h
+++ b/timer.h
@@ -11,6 +11,7 @@
 #define TIMER_H
 
 #include <QTime>
+#include <QTimer>
 
 class Timer : public QObject
 {


### PR DESCRIPTION
Under Qt 5.4 it seems to be necessary to add also to include  QTimer to compile
