### PR TITLE
soving openPortCtl issue

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -18,7 +18,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow),
    // open_button_text(tr(OPEN_BUTTON_TEXT)),
    // close_button_text(tr(CLOSE_BUTTON_TEXT)),
-    open_button_text(tr("Open")),
+    open_button_text(tr("&Open")),
     close_button_text(tr("Close / Reset")),
     absoluteAfterAxisAdj(false),
     checkLogWrite(false),


### PR DESCRIPTION
adding "&" symbol allows openPortCtl to succeed its' if condition. QAbstractButton doc says that text() attribute contains an & at its' beginning if no shortcut is given.
Allows to open port in a single click on button (previously had to click dozen of times)
